### PR TITLE
WIP: RO-CRATE extension

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -57,7 +57,19 @@ Address="https://github.com/ocfl-archive/gocfl"
 #
 [Extension]
 [Extension.NNNN-metafile]
-Source=""
+source=""
+
+[Extension.NNNN-ro-crate]
+# --ext-NNNN-ro-crate-enabled
+enabled="false"
+# --ext-NNNN-ro-crate-organisation
+organisation=""
+# --ext-NNNN-ro-crate-organisationID
+organisationID=""
+# --ext-NNNN-ro-crate-user
+user=""
+# --ext-NNNN-ro-crate-address
+address=""
 
 [Extension.NNNN-mets]
 # --ext-NNNN-mets-descriptive-metadata

--- a/data/fullextensions/object/NNNN-ro-crate/config.json
+++ b/data/fullextensions/object/NNNN-ro-crate/config.json
@@ -1,0 +1,6 @@
+{
+    "extensionName": "NNNN-ro-crate",
+    "storageType": "extension",
+    "storageName": "metadata",
+    "metaFileName": "info.json"
+}

--- a/docs/NNNN-ro-crate.md
+++ b/docs/NNNN-ro-crate.md
@@ -9,14 +9,17 @@
 
 ## Overview
 
-This object extension enables the use of an existing ro-crate-metadata.json 
-file to create an info.json metafile ([NNNN-metafile](NNNN-metafile.md)) 
-and integrates the ro-crate metadata into metadata-export and -viewer. 
+This object extension enables the use of an existing ro-crate-metadata.json
+file to create an info.json metafile ([NNNN-metafile](NNNN-metafile.md))
+and integrates the ro-crate metadata into metadata-export and -viewer.
 
 ### Usage Scenario
 
 To allow the use of ro-crate for various purposes, the ro-crate metadata extension
 makes sure, that ro-crate-metadata.json is available and can be used for further processing.
+
+The use of the ro-crate extension overrides the use of the metafile extension.
+The metadata file created at the end of the process will be `info.json`.
 
 ## Parameters
 
@@ -41,13 +44,15 @@ makes sure, that ro-crate-metadata.json is available and can be used for further
     * **Default:**
 
 * **Name:** `metafilename`
-    * **Description:** the name of the metadata file. Extension MUST be `.json`. If empty, no metafile will be created. This name MUST be the same as in [NNNN-metafile](NNNN-metafile.md). 
+    * **Description:** the name of the metadata file. Extension MUST be `.json`. If empty, no metafile will be created. This name MUST be the same as in [NNNN-metafile](NNNN-metafile.md).
     * **Type:** string
     * **Default:** `info.json`
 
 
 ## Procedure (tbd.)
 
+A metadata object is created at the configured storage location and is available
+for consumers to make use of during their OCFL archival workflows.
 
 ## Examples
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gin-contrib/multitemplate v1.1.0
 	github.com/gin-gonic/gin v1.10.0
+	github.com/go-test/deep v1.1.1
 	github.com/gomiran/volmgmt v0.0.0-20221201020756-5e535b6f4941
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/tink/go v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/go-playground/validator/v10 v10.25.0 h1:5Dh7cjvzR7BRZadnsVOzPhWsrwUr0
 github.com/go-playground/validator/v10 v10.25.0/go.mod h1:GGzBIJMuE98Ic/kJsBXbz1x/7cByt++cQ+YOuDM5wus=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
+github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
+github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU=
 github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
@@ -290,8 +292,8 @@ github.com/je4/goffmpeg v0.0.0-20220114092308-33ab9986404d h1:elX95ncLvCbNgkfD03
 github.com/je4/goffmpeg v0.0.0-20220114092308-33ab9986404d/go.mod h1:AU6NEns8+WYmI/UYzllN8CWM2jsIVO7jDz2FeCf7Ssw=
 github.com/je4/trustutil/v2 v2.0.28 h1:fRtvQzt3dNfin+ZE+n5N+RmeaispNfU2zdiXM/xkW/Y=
 github.com/je4/trustutil/v2 v2.0.28/go.mod h1:BB0sVfAHtXHvzewK6pFfNK5hj58OyIhpiyyg3/wkgfI=
-github.com/je4/utils/v2 v2.0.58 h1:mg32p68BW58dgPNWIHzLLBeyXYXjexWx0pVTywhFQFU=
-github.com/je4/utils/v2 v2.0.58/go.mod h1:ZbbHRxHnmHjoBohYmnMpwLzieADh48jVjELwCGod+TU=
+github.com/je4/utils/v2 v2.0.59 h1:CQPUlKttL+oVZbyxO3jBvsOXO0afb8Rpe0LgJL1/3l4=
+github.com/je4/utils/v2 v2.0.59/go.mod h1:ZbbHRxHnmHjoBohYmnMpwLzieADh48jVjELwCGod+TU=
 github.com/jedib0t/go-pretty/v6 v6.5.9 h1:ACteMBRrrmm1gMsXe9PSTOClQ63IXDUt03H5U+UV8OU=
 github.com/jedib0t/go-pretty/v6 v6.5.9/go.mod h1:zbn98qrYlh95FIhwwsbIip0LYpwSG8SUOScs+v9/t0E=
 github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=

--- a/gocfl/cmd/helper.go
+++ b/gocfl/cmd/helper.go
@@ -149,6 +149,11 @@ func InitExtensionFactory(
 		return extension.NewMetaFileFS(fsys)
 	})
 
+	logExtInit(logger, extension.ROCrateFileName)
+	extensionFactory.AddCreator(extension.ROCrateFileName, func(fsys fs.FS) (ocfl.Extension, error) {
+		return extension.NewROCrateFileFS(fsys)
+	})
+
 	logExtInit(logger, extension.IndexerName)
 	extensionFactory.AddCreator(extension.IndexerName, func(fsys fs.FS) (ocfl.Extension, error) {
 		ext, err := extension.NewIndexerFS(
@@ -186,12 +191,11 @@ func InitExtensionFactory(
 
 func GetExtensionParams() []*ocfl.ExtensionExternalParam {
 	var result = []*ocfl.ExtensionExternalParam{}
-
 	result = append(result, extension.GetIndexerParams()...)
 	result = append(result, extension.GetMetaFileParams()...)
 	result = append(result, extension.GetMetsParams()...)
+	result = append(result, extension.GetROCrateFileParams()...)
 	result = append(result, extension.GetContentSubPathParams()...)
-
 	return result
 }
 

--- a/justfile
+++ b/justfile
@@ -25,3 +25,7 @@ release:
 # Single-target release
 target:
   goreleaser build --single-target --clean -f .goreleaser.yml
+
+# docs
+docs:
+  godoc -http=localhost:6060

--- a/pkg/extension/NNNN-rocrate.go
+++ b/pkg/extension/NNNN-rocrate.go
@@ -1,0 +1,407 @@
+package extension
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"slices"
+	"strings"
+
+	"emperror.dev/errors"
+
+	"github.com/ocfl-archive/gocfl/v2/pkg/ocfl"
+	"github.com/ocfl-archive/gocfl/v2/pkg/rocrate"
+)
+
+// ROCrateFileName ...
+const ROCrateFileName = "NNNN-ro-crate"
+const ROCrateEnabled = "enabled"
+
+// ext prefix.
+const extPrefix = "ext"
+
+// Additional parameters for RO-CRATE metafile.
+const rOCrateParamOrg = "organisation"
+const rOCrateParamOrgID = "organisationID"
+const rOCrateParamUser = "user"
+const rOCrateParamAddress = "address"
+
+// RoCrateFileDescription ...
+const RoCrateFileDescription = "Description for RO-Crate extension"
+
+// registered ...
+const registered = false
+
+// ROCrateFileConfig ...
+type ROCrateFileConfig struct {
+	*ocfl.ExtensionConfig
+	// StorageType ...
+	StorageType string `json:"storageType"`
+	// StorageName ...
+	StorageName string `json:"storageName"`
+	// ...
+	MetaName string `json:"metaFileName,omitempty"`
+	// MetadataFile ...
+	MetadataFile []string `json:"metadataFile"`
+	// SupportedSchema ...
+	SupportedSchema []string `json:"supportedSchema"`
+	// Documentation ...
+	Documentation []string `json:"documentation"`
+}
+
+// ROCrateFile provides a way to record configuration and other
+// metadata.
+type ROCrateFile struct {
+	// combination of the config and other metadata.
+	*ROCrateFileConfig
+	fsys       fs.FS
+	stored     bool
+	info       map[string][]byte
+	enabled    bool
+	userConfig *userConfig
+}
+
+// userConfig stores the additional metadata a user needs to provide to
+// complete the info.json object.
+type userConfig struct {
+	organisation   string
+	organisationID string
+	user           string
+	address        string
+}
+
+// GetROCrateFileParams ...
+func GetROCrateFileParams() []*ocfl.ExtensionExternalParam {
+	return []*ocfl.ExtensionExternalParam{
+		{
+			ExtensionName: ROCrateFileName,
+			Functions:     []string{"add", "create"},
+			Param:         ROCrateEnabled,
+			Description:   "replace metafile extension functionality if enabled and map RO-CRATE metadata",
+			Default:       "false",
+		},
+		{
+			ExtensionName: ROCrateFileName,
+			Functions:     []string{"add", "create"},
+			Param:         rOCrateParamOrg,
+			Description:   "provide insitutional organisation to the RO-CRATE extension metadata",
+			Default:       "",
+		},
+		{
+			ExtensionName: ROCrateFileName,
+			Functions:     []string{"add", "create"},
+			Param:         rOCrateParamOrgID,
+			Description:   "provide insitutional organisation ID to the RO-CRATE extension metadata",
+			Default:       "",
+		},
+		{
+			ExtensionName: ROCrateFileName,
+			Functions:     []string{"add", "create"},
+			Param:         rOCrateParamUser,
+			Description:   "provide insitutional user to the RO-CRATE extension metadata",
+			Default:       "",
+		},
+		{
+			ExtensionName: ROCrateFileName,
+			Functions:     []string{"add", "create"},
+			Param:         rOCrateParamAddress,
+			Description:   "provide user address to the RO-CRATE extension metadata",
+			Default:       "",
+		},
+	}
+}
+
+// NewROCrateFileFS ...
+func NewROCrateFileFS(fsys fs.FS) (*ROCrateFile, error) {
+	data, err := fs.ReadFile(fsys, "config.json")
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot read config.json")
+	}
+	var config = &ROCrateFileConfig{
+		ExtensionConfig: &ocfl.ExtensionConfig{ExtensionName: ROCrateFileName},
+		StorageType:     "extension",
+		StorageName:     "metadata",
+	}
+	if err := json.Unmarshal(data, config); err != nil {
+		return nil, errors.Wrapf(err, "cannot unmarshal DirectCleanConfig '%s'", string(data))
+	}
+	rcFile, err := NewROCrateFile(config)
+	return rcFile, err
+}
+
+// NewROCrateFile provides a helper to create a new object that helps us
+// to understand the internals of the extension
+func NewROCrateFile(config *ROCrateFileConfig) (*ROCrateFile, error) {
+	rcFile := &ROCrateFile{
+		ROCrateFileConfig: config,
+		info:              map[string][]byte{},
+	}
+	// check internal extension name is correct..
+	if config.ExtensionName != rcFile.GetName() {
+		return nil, errors.New(
+			fmt.Sprintf(
+				"invalid extension name'%s'for extension %s",
+				config.ExtensionName,
+				rcFile.GetName(),
+			),
+		)
+	}
+	return rcFile, nil
+}
+
+// Terminate ...
+func (rcFile *ROCrateFile) Terminate() error {
+	// not implemented.
+	return nil
+}
+
+// GetFS ...
+func (rcFile *ROCrateFile) GetFS() fs.FS {
+	return rcFile.fsys
+}
+
+func (rcFile *ROCrateFile) GetConfig() any {
+	return rcFile.ROCrateFileConfig
+}
+
+// IsRegistered describes whether this is an official GOCL extension.
+func (rcFile *ROCrateFile) IsRegistered() bool {
+	return registered
+}
+
+// ParamROCrateEnabled provides a mechanism for retrieivng the enabled
+// parameter from the user's configuration, e.g. given a param map,
+// call `param[ParamRoCrateEnabled()]“.
+func ParamROCrateEnabled() string {
+	return fmt.Sprintf("%s-%s-%s", extPrefix, ROCrateFileName, ROCrateEnabled)
+}
+
+// paramROCrateOrg ...
+func paramROCrateOrg() string {
+	return fmt.Sprintf("%s-%s-%s", extPrefix, ROCrateFileName, rOCrateParamOrg)
+}
+
+// paramROCrateOrgID ...
+func paramROCrateOrgID() string {
+	return fmt.Sprintf("%s-%s-%s", extPrefix, ROCrateFileName, rOCrateParamOrgID)
+}
+
+// paramROCrateUser ...
+func paramROCrateUser() string {
+	return fmt.Sprintf("%s-%s-%s", extPrefix, ROCrateFileName, rOCrateParamUser)
+}
+
+// paramROCrateAddress ...
+func paramROCrateAddress() string {
+	return fmt.Sprintf("%s-%s-%s", extPrefix, ROCrateFileName, rOCrateParamAddress)
+}
+
+// SetParams allows us to set parameters provided to the extension via
+// the config, e.g. CLI (or TOML?)
+func (rcFile *ROCrateFile) SetParams(params map[string]string) error {
+	if params == nil {
+		// this is unlikely to happen.
+		errors.New("extension parameters are blank")
+	}
+	enabled := params[ParamROCrateEnabled()]
+	if strings.ToLower(enabled) != "true" {
+		rcFile.enabled = false
+		return nil
+	}
+	rcFile.enabled = true
+	userConfig := userConfig{}
+	rcFile.userConfig = &userConfig
+	rcFile.userConfig.organisation = params[paramROCrateOrg()]
+	rcFile.userConfig.organisationID = params[paramROCrateOrgID()]
+	rcFile.userConfig.user = params[paramROCrateUser()]
+	rcFile.userConfig.address = params[paramROCrateAddress()]
+	return nil
+}
+
+// SetFS ...
+func (rcFile *ROCrateFile) SetFS(fsys fs.FS, create bool) {
+	rcFile.fsys = fsys
+}
+
+// GetName returns the name of this extension to the caller.
+func (rcFile *ROCrateFile) GetName() string {
+	return ROCrateFileName
+}
+
+// WriteConfig ...
+func (rcFile *ROCrateFile) WriteConfig() error {
+	// not implemented.
+	return nil
+}
+
+// UpdateObjectBefore (before a new version of an OCFL object is
+// created...) TODO...
+func (rcFile *ROCrateFile) UpdateObjectBefore(object ocfl.Object) error {
+	// not implemented.
+	return nil
+}
+
+// UpdateObjectAfter (after all content to the new version is written)
+func (rcFile *ROCrateFile) UpdateObjectAfter(object ocfl.Object) error {
+	// not implemented.
+	return nil
+
+}
+
+// GetMetadata (is called by any tool, which wants to report about
+// content, e.g. data will be retrieved from here for use in METS.xml
+// or PREMIS.xml.
+func (rcFile *ROCrateFile) GetMetadata(object ocfl.Object) (map[string]any, error) {
+	if !rcFile.enabled {
+		return nil, nil
+	}
+	var err error
+	var result = map[string]any{}
+	inventory := object.GetInventory()
+	versions := inventory.GetVersionStrings()
+	slices.Reverse(versions)
+	var metadata []byte
+	for _, ver := range versions {
+		var ok bool
+		if metadata, ok = rcFile.info[ver]; ok {
+			break
+		}
+		if metadata, err = ocfl.ReadFile(
+			object,
+			rcFile.MetaName,
+			ver,
+			rcFile.StorageType,
+			rcFile.StorageName,
+			rcFile.fsys); err == nil {
+			break
+		}
+	}
+	if metadata == nil {
+		return nil, errors.Wrapf(err, "cannot read %s", rcFile.MetaName)
+	}
+	var metaStruct = map[string]any{}
+	if err := json.Unmarshal(metadata, &metaStruct); err != nil {
+		return nil, errors.Wrapf(err, "cannot unmarshal '%s'", rcFile.MetaName)
+	}
+	result[""] = metaStruct
+	return result, nil
+}
+
+// findROCrateMeta looks for the RO-CRATE metadata file within the
+// objects spplied to the function.
+func (rcFile *ROCrateFile) findROCrateMeta(stateFiles []string) bool {
+	f := stateFiles[0]
+	if f != "data/ro-crate-metadata.json" {
+		return false
+	}
+	return true
+}
+
+// copyStream allows StreamObject to make a copy of a reader so that it
+// can be given back safely to the caller and other stream functions
+// can be performed on the object.
+func copyStream(reader io.Reader) (io.Reader, error) {
+	buf := &bytes.Buffer{}
+	_, err := io.Copy(buf, reader)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// infoJSONExists provides a guard that ensures we know what we're
+// doing with info.json and its replacement when driven by the
+// RO-CRATE extension.
+func infoJSONExists(object ocfl.Object, metaFileName string) bool {
+	inventory := object.GetInventory()
+	for _, v := range inventory.GetManifest() {
+		s := strings.Split(v[0], "/")
+		if s[len(s)-1] == metaFileName {
+			return true
+		}
+	}
+	return false
+}
+
+// writeMetafile outputs the configured metadata file and content to
+// the metadata storage location.
+func (rcFile *ROCrateFile) writeMetafile(object ocfl.Object, rcMeta string) error {
+	if !rcFile.enabled {
+		return nil
+	}
+	if infoJSONExists(object, rcFile.MetaName) {
+		return fmt.Errorf("%s exists, ensure metafile extension is not configured as on", rcFile.MetaName)
+	}
+	mappingFile := rcFile.MetaName
+	log.Println(mappingFile)
+	data := []byte(rcMeta)
+	if _, err := object.AddReader(
+		io.NopCloser(
+			bytes.NewBuffer(data),
+		),
+		[]string{mappingFile},
+		rcFile.StorageName,
+		true,
+		false,
+	); err != nil {
+		log.Println("there was an error")
+		return err
+	}
+	return nil
+}
+
+// writeConfigValues completes a ro-crate info.json output by adding
+// user or insitution supplied values to the structure.
+func (rcFile *ROCrateFile) writeConfigValues(rcMeta *rocrate.GocflSummary) {
+	rcMeta.Organisation = rcFile.userConfig.organisation
+	rcMeta.OrganisationID = rcFile.userConfig.organisationID
+	rcMeta.User = rcFile.userConfig.user
+	rcMeta.Address = rcFile.userConfig.address
+}
+
+func (rcFile *ROCrateFile) StreamObject(
+	object ocfl.Object,
+	reader io.Reader,
+	stateFiles []string,
+	dest string,
+) error {
+	if !rcFile.enabled {
+		return nil
+	}
+	if !rcFile.findROCrateMeta(stateFiles) {
+		return nil
+	}
+	inventory := object.GetInventory()
+	if inventory == nil {
+		return errors.New("no inventory available")
+	}
+	// copy file so that it can then be sent to another interface to
+	// be read. In this case a ro-crate-metadata json reader.
+	metaCopy, err := copyStream(reader)
+	if err != nil {
+		return err
+	}
+	processed, err := rocrate.ProcessMetadataStream(metaCopy)
+	if err != nil {
+		return errors.Wrapf(err, "cannot process RO-CRATE metadata")
+	}
+	rcMeta, _ := processed.GOCFLSummary()
+	rcFile.writeConfigValues(&rcMeta)
+	metaString := rcMeta.String()
+	if metaString == rocrate.StringerError {
+		return errors.New("problem creating GOCFL metadata JSON")
+	}
+	rcFile.writeMetafile(object, rcMeta.String())
+	rcFile.info[inventory.GetHead()] = []byte(rcMeta.String())
+	return nil
+}
+
+// check interface satisfaction
+var (
+	_ ocfl.Extension             = &ROCrateFile{}
+	_ ocfl.ExtensionObjectChange = &ROCrateFile{}
+	_ ocfl.ExtensionMetadata     = &ROCrateFile{}
+)

--- a/pkg/rocrate/rocrate.go
+++ b/pkg/rocrate/rocrate.go
@@ -1,0 +1,324 @@
+// Package rocrate enables simple processing of ro-crate data so that
+// it can be remapped in custome metadata.
+//
+// For additional reference for some of the structural information in
+// this module, including cardinality, please look at crate-o:
+//
+//   - https://language-research-technology.github.io/crate-o
+package rocrate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+)
+
+var versions []string = []string{
+	"https://w3id.org/ro/crate/1.1/context",
+}
+
+type rocrateMeta struct {
+	LDContext any     `json:"@context"`
+	Graph     []graph `json:"@graph"`
+}
+
+type graph struct {
+	ID               string                 `json:"@id"`
+	Name             *StringOrSlice         `json:"name,omitempty"`
+	Type             *StringOrSlice         `json:"@type,omitempty"`
+	About            *NodeIdentifierOrSlice `json:"about,omitempty"`
+	Author           *NodeIdentifierOrSlice `json:"author,omitempty"`
+	Affiliation      *NodeIdentifierOrSlice `json:"affiliation,omitempty"`
+	Conforms         *NodeIdentifierOrSlice `json:"conformsTo,omitempty"`
+	ContentLocation  *NodeIdentifierOrSlice `json:"contentLocation,omitempty"`
+	ContentURL       *NodeIdentifierOrSlice `json:"contentUrl,omitempty"`
+	DatePublished    string                 `json:"datePublished,omitempty"`
+	Description      *StringOrSlice         `json:"description,omitempty"`
+	EncodingFormat   string                 `json:"enncodingFormat,omitempty"`
+	FamilyName       string                 `json:"familyName,omitempty"`
+	Funder           *NodeIdentifierOrSlice `json:"funder,omitempty"`
+	GivenName        string                 `json:"givenName,omitempty"`
+	HasPart          *NodeIdentifierOrSlice `json:"hasPart,omitempty"`
+	Identifier       string                 `json:"identifier,omitempty"`
+	Keywords         *StringOrSlice         `json:"keywords,omitempty"`
+	License          *NodeIdentifierOrSlice `json:"license,omitempty"`
+	Latitude         string                 `json:"latitude,omitempty"`
+	Longitude        string                 `json:"longitude,omitempty"`
+	Publisher        *NodeIdentifierOrSlice `json:"publisher,omitempty"`
+	TemporalCoverage string                 `json:"temporalCoverage,omitempty"`
+	URL              string                 `json:"url,omitempty"`
+}
+
+type rocrateContext struct {
+	string
+	vocab map[string]string
+}
+
+// Context provides a helpter to return the RO-CRATE context from the
+// RO-CRATE data structure.
+//
+// NB: we must be able to cast to rocrateContext some way, but it is
+// currently eluding me. We should circle back to this.
+func (rcMeta *rocrateMeta) Context() string {
+
+	// E.g.
+	//
+	// "context":
+	// [
+	//		https://w3id.org/ro/crate/1.1/context,
+	//		map[@vocab:http://schema.org/],
+	// ]
+	//
+	// or
+	//
+	// "@context": "https://example.com/vocab/context"
+	//
+
+	switch rcMeta.LDContext.(type) {
+	case string:
+		return rcMeta.LDContext.(string)
+	default:
+		// expect string/map variant
+	}
+	rcContext, ok := rcMeta.LDContext.([]interface{})
+	if !ok {
+		return fmt.Sprintf("cannot determine @context from json-ld input: %v", rcMeta.LDContext)
+	}
+	context := (rcContext[0].(string))
+	return context
+}
+
+// RocrateSummary provides a summary structure we can access safefly
+// so as to reason about the data in a ro-crate.
+// The data in this structure mirrors the basic information in the
+// ro-create-preview.htm file.
+type RocrateSummary struct {
+	// ID via graph[1].
+	ID string
+	// Name via graph[1].
+	Name []string
+	// Type via graph[1].
+	Type []string
+	// Description via graph[1].
+	Description []string
+	// DatePublished via graph[1].
+	DatePublished string
+	// Autho via graph[1].
+	Author []string
+	// License via graph[1].
+	License string
+	// HasPart via graph[1].
+	HasPart []string
+	// ContentURL via graph[1].
+	ContentURL []string
+	// Keywords via graph[1].
+	Keywords []string
+	// Published via graph[1].
+	Publisher []string
+	// About provides an alias for 'Referenced by' which refers to
+	// sections of the RO-CRATE that reference this summary. It takes
+	// this information from the about field.
+	//
+	// via graph[0].
+	About string
+}
+
+const StringerError = "error in ro-crate stringer"
+
+// String provides stringer functions for the rocrate summary object.
+func (rcSummary RocrateSummary) String() string {
+	ret, err := json.MarshalIndent(rcSummary, " ", " ")
+	if err != nil {
+		return fmt.Sprintf("%s: %s", StringerError, err)
+	}
+	return string(ret)
+}
+
+// newSummary creates a new ro-crate summary to provide safe access
+// from the caller.
+func newSummary() RocrateSummary {
+	return RocrateSummary{
+		"",
+		[]string{},
+		[]string{},
+		[]string{},
+		"",
+		[]string{},
+		"",
+		[]string{},
+		[]string{},
+		[]string{},
+		[]string{},
+		"",
+	}
+}
+
+// Summary returns a summary ro-crate structure from the data we
+// have in-memory.
+func (rcMeta rocrateMeta) Summary() (RocrateSummary, error) {
+
+	if len(rcMeta.Graph) == 0 {
+		return RocrateSummary{}, fmt.Errorf("ro-crate-metadata.json is empty")
+	}
+	if len(rcMeta.Graph) == 1 {
+		return RocrateSummary{}, fmt.Errorf("ro-crate-metadata.json is non-conformant")
+	}
+	summary := newSummary()
+	summary.ID = rcMeta.Graph[1].ID
+	if rcMeta.Graph[1].Name != nil {
+		summary.Name = rcMeta.Graph[1].Name.Value()
+	}
+	if rcMeta.Graph[1].Type != nil {
+		summary.Type = rcMeta.Graph[1].Type.Value()
+	}
+	if rcMeta.Graph[1].Description != nil {
+		summary.Description = rcMeta.Graph[1].Description.Value()
+	}
+	summary.DatePublished = rcMeta.Graph[1].DatePublished
+	if rcMeta.Graph[1].Author != nil {
+		summary.Author = rcMeta.Graph[1].Author.StringSlice()
+	}
+	if rcMeta.Graph[1].License != nil {
+		license := rcMeta.Graph[1].License.StringSlice()
+		if len(license) != 0 {
+			summary.License = license[0]
+		}
+	}
+	if rcMeta.Graph[1].HasPart != nil {
+		summary.HasPart = rcMeta.Graph[1].HasPart.StringSlice()
+	}
+	if rcMeta.Graph[1].Keywords != nil {
+		summary.Keywords = rcMeta.Graph[1].Keywords.Value()
+	}
+	if rcMeta.Graph[1].Publisher != nil {
+		summary.Publisher = rcMeta.Graph[1].Publisher.StringSlice()
+	}
+	if rcMeta.Graph[1].ContentURL != nil {
+		summary.ContentURL = rcMeta.Graph[1].ContentURL.StringSlice()
+	}
+	if rcMeta.Graph[0].About != nil {
+		about := rcMeta.Graph[0].About.StringSlice()
+		if len(about) != 0 {
+			summary.About = about[0]
+		}
+	}
+	return summary, nil
+}
+
+// String provides stringer functions for the rocrate meta object.
+func (rcMeta rocrateMeta) String() string {
+	ret, err := json.MarshalIndent(rcMeta, " ", " ")
+	if err != nil {
+		return fmt.Sprintf("%s: %s", StringerError, err)
+	}
+	return string(ret)
+}
+
+/* StringOrSlice type and handler:
+
+For more info on the type handling below:
+
+StringOrSlice:
+   https://gitlab.com/flimzy/talks/-/blob/master/2020/go-json/string-or-array.go
+
+*/
+
+// StringOrSlice represents a type that can interpret both single-value
+// strings or slices of strings.
+type StringOrSlice []string
+
+// Implement Unmarshal for the StringOrSlice type.
+func (s *StringOrSlice) UnmarshalJSON(d []byte) error {
+	if d[0] == '"' {
+		var v string
+		err := json.Unmarshal(d, &v)
+		*s = StringOrSlice{v}
+		return err
+	}
+	var v []string
+	err := json.Unmarshal(d, &v)
+	*s = StringOrSlice(v)
+	return err
+}
+
+// Return the StringOrSlice value as something sensible.
+func (s StringOrSlice) Value() []string {
+	return s
+}
+
+// String provides a stringer method for this type. It might not
+// be needed eventually.
+func (s StringOrSlice) String() string {
+	var out string = "["
+	for _, v := range s {
+		out = fmt.Sprintf("%s%s; ", out, v)
+	}
+	out = fmt.Sprintf("%s]", strings.TrimSpace(out))
+	return out
+}
+
+// Node-identifier handlers. These seem to only contain relative
+// links in the RO-CRATE specification.
+
+// nodePrimitive look like they only contain links. relative, or
+// absolute, in RO-CRATE metadata. They can be single-value objects
+// or slices of objects.
+type nodeIdentifier struct {
+	ID string `json:"@id"`
+}
+
+type NodeIdentifierOrSlice []nodeIdentifier
+
+func (s *NodeIdentifierOrSlice) UnmarshalJSON(d []byte) error {
+	if d[0] == '{' {
+		var v nodeIdentifier
+		err := json.Unmarshal(d, &v)
+		*s = NodeIdentifierOrSlice{v}
+		return err
+	}
+	if d[0] == '"' {
+		// we might have a string that needs converting. This technique
+		// might also work for all RO-CRATE objects, so we should
+		// circle back to this.
+		var v nodeIdentifier
+		converted := fmt.Sprintf("{\"@id\": %v}", string(d))
+		err := json.Unmarshal([]byte(converted), &v)
+		*s = NodeIdentifierOrSlice{v}
+		return err
+	}
+	var v []nodeIdentifier
+	err := json.Unmarshal(d, &v)
+	*s = NodeIdentifierOrSlice(v)
+	return err
+}
+
+func (s NodeIdentifierOrSlice) Value() []nodeIdentifier {
+	return s
+}
+
+func (s NodeIdentifierOrSlice) StringSlice() []string {
+	var res []string
+	for _, v := range s {
+		res = append(res, v.ID)
+	}
+	return res
+}
+
+// ProcessMetadataStream enables processing of ro-crate-metadata.json
+// and return in the simple structs made available in this package.
+func ProcessMetadataStream(metaObject io.Reader) (rocrateMeta, error) {
+	buf := new(bytes.Buffer)
+	_, err := io.Copy(buf, metaObject)
+	if err != nil {
+		return rocrateMeta{}, err
+	}
+	meta := rocrateMeta{}
+	json.Unmarshal(buf.Bytes(), &meta)
+	if !slices.Contains(versions, meta.Context()) {
+		return rocrateMeta{}, fmt.Errorf("cannot process this version: %s", meta.Context())
+	}
+	return meta, nil
+}

--- a/pkg/rocrate/rocrate_custom_view.go
+++ b/pkg/rocrate/rocrate_custom_view.go
@@ -1,0 +1,135 @@
+// Custom view/summary objects for consumers of RO-CRATE metadata.
+package rocrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const stringSeparator = "; "
+
+// GocflSummary provides a summary compatible with gocfl user's
+// expectations for the info.json object.
+//
+/*
+	-- via RO-CRATE.
+	signature       = id
+	title           = name
+	description     = description
+	created         = datePublished
+	sets            = @type
+	keywords        = keywords
+	licenses        = license
+
+	-- output at runtime.
+	last_changed    = now()
+
+	-- via GOCFL config.
+	organisation_id = user.config
+	organisation    = user.config
+	user            = user.config
+	address         = user.config
+
+*/
+//
+type GocflSummary struct {
+	// provided by ro-crate.
+	Signature   string `json:"signature"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Created     string `json:"created"`
+	Sets        string `json:"sets"`
+	Keywords    string `json:"keywords"`
+	Licenses    string `json:"licenses"`
+	// generated at runtime, e.g. time.Now().
+	LastChanged string `json:"last_changed"`
+	// provided by caller.
+	OrganisationID string `json:"organisation_id"`
+	Organisation   string `json:"organisation"`
+	User           string `json:"user"`
+	Address        string `json:"address"`
+}
+
+// newGocflSummary returns an initialized gocflSummary object for
+// maximum safety.
+func newGocflSummary() GocflSummary {
+	return GocflSummary{
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		// provided by caller.
+		"",
+		"",
+		"",
+		"",
+		"",
+	}
+}
+
+// String provides stringer functions for the gocfl summary object.
+func (gocflSummary GocflSummary) String() string {
+	ret, err := json.MarshalIndent(gocflSummary, " ", " ")
+	if err != nil {
+		return fmt.Sprintf("%s: %s", StringerError, err)
+	}
+	return string(ret)
+}
+
+// joinStrings simplifies string join functions for us so that we can
+// exchange string separator values easily.
+func joinStrings(inputString []string) string {
+	return strings.Join(inputString, stringSeparator)
+}
+
+// currentTime provides a module level approach to replacing the time
+// functions, e.g. for testing.
+var currentTime = getTime
+
+// getTime provides a helpter to return the current time formatted as
+// a string.
+func getTime(utc bool) string {
+	if utc {
+		t := time.Now().UTC()
+		return t.Format("2006-01-02T15:04:05Z")
+	}
+	t := time.Now()
+	return t.Format("2006-01-02T15:04:05")
+}
+
+func (rcMeta rocrateMeta) GOCFLSummary() (GocflSummary, error) {
+	if len(rcMeta.Graph) == 0 {
+		return GocflSummary{}, fmt.Errorf("ro-crate-metadata.json is empty")
+	}
+	if len(rcMeta.Graph) == 1 {
+		return GocflSummary{}, fmt.Errorf("ro-crate-metadata.json is non-conformant")
+	}
+	summary := newGocflSummary()
+	summary.Signature = rcMeta.Graph[1].ID
+	if rcMeta.Graph[1].Name != nil {
+		name := rcMeta.Graph[1].Name.Value()
+		if len(name) > 0 {
+			summary.Title = rcMeta.Graph[1].Name.Value()[0]
+		}
+	}
+	if rcMeta.Graph[1].Type != nil {
+		summary.Sets = joinStrings(rcMeta.Graph[1].Type.Value())
+	}
+	if rcMeta.Graph[1].Description != nil {
+		summary.Description = joinStrings(rcMeta.Graph[1].Description.Value())
+	}
+	summary.Created = rcMeta.Graph[1].DatePublished
+	if rcMeta.Graph[1].License != nil {
+		summary.Licenses = joinStrings(rcMeta.Graph[1].License.StringSlice())
+	}
+	if rcMeta.Graph[1].Keywords != nil {
+		summary.Keywords = joinStrings(rcMeta.Graph[1].Keywords.Value())
+	}
+	summary.LastChanged = currentTime(true)
+	return summary, nil
+}

--- a/pkg/rocrate/rocrate_data_test.go
+++ b/pkg/rocrate/rocrate_data_test.go
@@ -1,0 +1,564 @@
+package rocrate
+
+// simplecontext contains bare minimum context.
+var simpleContext []byte = []byte(`
+{
+  "@context": "https://w3id.org/ro/crate/1.1/context",
+  "@graph": [
+  ]
+}
+`)
+
+// complexcontext provides further information about the schema and
+// vocabulary.
+var complexContext []byte = []byte(`
+{
+  "@context": [
+    "https://w3id.org/ro/crate/1.1/context",
+    {
+      "@vocab": "http://schema.org/"
+    }
+  ],
+  "@graph": [
+  ]
+}
+`)
+
+// Variants of different values that can be single values or slices.
+//
+// nameTest provides a way of testing a single value name or a slice
+// of names.
+var nameTest []byte = []byte(`
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        {
+            "@vocab": "http://schema.org/"
+        }
+    ],
+    "@graph": [
+        {
+            "@id": "test1",
+            "name": [
+                "name one",
+                "name two"
+            ]
+        },
+        {
+            "@id": "test2",
+            "name": "name one"
+        }
+    ]
+}
+`)
+
+// keywordTest provides a way to test a single-value keyword or a
+// slice of keywords.
+var keywordTest []byte = []byte(`
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        {
+            "@vocab": "http://schema.org/"
+        }
+    ],
+    "@graph": [
+        {
+            "@id": "test1",
+            "keywords": [
+                "kw1",
+                "kw2"
+            ]
+        },
+        {
+            "@id": "test2",
+            "keywords": "kw1"
+        }
+    ]
+}
+`)
+
+// typeTest provides a way to test a single-value type or a slice of
+// values for the same key.
+var typeTest []byte = []byte(`
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        {
+            "@vocab": "http://schema.org/"
+        }
+    ],
+    "@graph": [
+        {
+            "@id": "test1",
+            "@type": [
+                "Person",
+                "Artist"
+            ]
+        },
+        {
+            "@id": "test2",
+            "@type": "Person"
+        }
+    ]
+}
+`)
+
+// authorTest provides a way to test a single-value author, or a slice
+// of author values.
+var authorTest []byte = []byte(`
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        {
+            "@vocab": "http://schema.org/"
+        }
+    ],
+    "@graph": [
+        {
+            "@id": "test1",
+            "author": [
+                {
+                    "@id": "https://orcid.org/1234-0003-1974-0000"
+                },
+                {
+                    "@id": "#Yann"
+                },
+                {
+                    "@id": "#Organization-SMUC"
+                }
+            ]
+        },
+		{
+            "@id": "test2",
+            "author": {
+				"@id": "https://orcid.org/0000-0003-1974-1234"
+            }
+        }
+    ]
+}
+`)
+
+var hasPartTest []byte = []byte(`
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        {
+            "@vocab": "http://schema.org/"
+        }
+    ],
+    "@graph": [
+		{
+            "@id": "test1",
+            "hasPart": {
+				"@id": "part1"
+            }
+        },
+        {
+            "@id": "test2",
+            "hasPart": [
+                {
+                    "@id": "part1"
+                },
+                {
+                    "@id": "part2"
+                },
+                {
+                    "@id": "part3"
+                }
+            ]
+        }
+    ]
+}
+`)
+
+var licenseTest []byte = []byte(`
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        {
+            "@vocab": "http://schema.org/"
+        }
+    ],
+    "@graph": [
+        {
+            "@id": "test1",
+            "license": "https://spdx.org/licenses/license1"
+        },
+        {
+            "@id": "test2",
+            "license": {
+                "@id": "http://spdx.org/licenses/license2"
+            }
+        }
+    ]
+}
+`)
+
+// afternoonDrinks is an example RO-CRATE meta created from Dataverse.
+var afternoonDrinks []byte = []byte(`
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        {
+            "@vocab": "http://schema.org/"
+        }
+    ],
+    "@graph": [
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "identifier": "ro-crate-metadata.json",
+            "about": {
+                "@id": "./RC0E772B3021E7E40C2BBDE657"
+            }
+        },
+        {
+            "@id": "./RC0E772B3021E7E40C2BBDE657",
+            "@type": "Dataset",
+            "name": "A study of my afternoon drinks",
+            "description": [
+                "A study of my afternoon consumption one week in 2018",
+                "Exported from Dataverse"
+            ],
+            "datePublished": "2018",
+            "license": "https://spdx.org/licenses/CC0-1.0.html",
+            "hasPart": [
+                {
+                    "@id": "metadata/agents.json"
+                },
+                {
+                    "@id": "metadata/dataset.json"
+                },
+                {
+                    "@id": "Drinkscitation-endnote.xml"
+                },
+                {
+                    "@id": "Drinks.tab"
+                },
+                {
+                    "@id": "Drinks.csv"
+                },
+                {
+                    "@id": "Drinkscitation-ris.ris"
+                },
+                {
+                    "@id": "Drinkscitation-bib.bib"
+                },
+                {
+                    "@id": "Drinks.RData"
+                },
+                {
+                    "@id": "Drinks-ddi.xml"
+                }
+            ],
+            "contentUrl": [],
+            "keywords": [
+                "dataverse",
+                "study",
+                "observational-study"
+            ],
+            "author": {
+                "@id": "#Ross_Spencer-1"
+            },
+            "publisher": {
+                "@id": "https://ror.org/02s6k3f65"
+            },
+            "funder": {
+                "@id": "https://ror.org/02s6k3f65"
+            }
+        },
+        {
+            "@id": "metadata/agents.json",
+            "@type": "File"
+        },
+        {
+            "@id": "metadata/dataset.json",
+            "@type": "File"
+        },
+        {
+            "@id": "Drinkscitation-endnote.xml",
+            "@type": "File"
+        },
+        {
+            "@id": "Drinks.tab",
+            "@type": "File"
+        },
+        {
+            "@id": "Drinks.csv",
+            "@type": "File",
+            "description": "Primary information recorded for the study",
+            "datePublished": "2018",
+            "contentLocation": {
+                "@id": "#Toronto-1"
+            }
+        },
+        {
+            "@id": "Drinkscitation-ris.ris",
+            "@type": "File"
+        },
+        {
+            "@id": "Drinkscitation-bib.bib",
+            "@type": "File"
+        },
+        {
+            "@id": "Drinks.RData",
+            "@type": "File"
+        },
+        {
+            "@id": "Drinks-ddi.xml",
+            "@type": "File"
+        },
+        {
+            "@id": "#CSV_data_with_Dataverse_citation-1",
+            "@type": "Dataset",
+            "name": "CSV_data_with_Dataverse_citation-1",
+            "license": "https://spdx.org/licenses/CC0-1.0.html"
+        },
+        {
+            "@id": "#Ross_Spencer-1",
+            "@type": "Person",
+            "name": "Ross",
+            "familyName": "Spencer",
+            "givenName": "b33tk33p3r",
+            "funder": {
+                "@id": "https://ror.org/02s6k3f65"
+            },
+            "affiliation": {
+                "@id": "https://ror.org/02s6k3f65"
+            },
+            "address": "101 example.com str.",
+            "email": "ross@example.com",
+            "identifier": "RS4FCB6A76D83F4B39B542EF5D"
+        },
+        {
+            "@id": "https://ror.org/02s6k3f65",
+            "@type": "Organization",
+            "name": "University of Basel"
+        },
+        {
+            "@id": "#Toronto-1",
+            "@type": "Place",
+            "name": "Toronto-1",
+            "description": "A location somewhere in Canada",
+            "keywords": [
+                "dataverse",
+                "csv",
+                "behavioral analysis"
+            ]
+        }
+    ]
+}
+`)
+
+// carprentriesCrate conforms to the example crate created as part of
+// the RO-CRATE carpentries tutorial.
+var carpentriesCrate []byte = []byte(`
+{
+	"@context": "https://w3id.org/ro/crate/1.1/context",
+	"@graph": [
+	  {
+		"@id": "ro-crate-metadata.json",
+		"@type": "CreativeWork",
+		"conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"},
+		"about": {"@id": "./"}
+	  },
+	  {
+		"@id": "./",
+		"@type": ["Dataset", "LearningResource"],
+		"hasPart": [
+		  {"@id": "data.csv"}
+		],
+		"name": "Example dataset for RO-Crate specification",
+		"description": "Official rainfall readings for Katoomba, NSW 2022, Australia",
+		"datePublished": "2023-05-22T12:03:00+0100",
+		"license": {"@id": "http://spdx.org/licenses/CC0-1.0"},
+		"author": { "@id": "https://orcid.org/0000-0002-1825-0097" },
+		"publisher": {"@id": "https://ror.org/05gq02987"}
+	  },
+	  {
+		"@id": "data.csv",
+		"@type": "File",
+		"name": "Rainfall Katoomba 2022-02",
+		"description": "Rainfall data for Katoomba, NSW Australia February 2022",
+		"encodingFormat": "text/csv",
+		"license": {"@id": "https://creativecommons.org/licenses/by-nc-sa/4.0/"}
+	  },
+	  {
+		"@id": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+		"@type": "CreativeWork",
+		"name": "CC BY-NC-SA 4.0 International",
+		"description": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International"
+	  },
+	  {
+		"@id": "http://spdx.org/licenses/CC0-1.0",
+		"@type": "CreativeWork",
+		"name": "CC0-1.0",
+		"description": "Creative Commons Zero v1.0 Universal",
+		"url": "https://creativecommons.org/publicdomain/zero/1.0/"
+	  },
+	  {
+		"@id": "https://orcid.org/0000-0002-1825-0097",
+		"@type": "Person",
+		"name": "Josiah Carberry",
+		"affiliation": {
+		  "@id": "https://ror.org/05gq02987"
+		}
+	  },
+	  {
+		"@id": "https://ror.org/05gq02987",
+		"@type": "Organization",
+		"name": "Brown University",
+		"url": "http://www.brown.edu/"
+	  }
+	]
+  }
+`)
+
+// specCrate is an example of a ro-crate-metadata.json file found in
+// the wild.
+var specCrate []byte = []byte(`
+  { "@context": "https://w3id.org/ro/crate/1.1/context",
+  "@graph": [
+
+    {
+      "@type": "CreativeWork",
+      "@id": "ro-crate-metadata.json",
+      "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"},
+      "about": {"@id": "./"},
+      "description": "RO-Crate Metadata File Descriptor (this file)"
+    },
+    {
+      "@id": "./",
+      "@type": "Dataset",
+      "name": "Example RO-Crate",
+      "description": "The RO-Crate Root Data Entity",
+      "hasPart": [
+        {"@id": "data1.txt"},
+        {"@id": "data2.txt"}
+      ]
+    },
+    {
+      "@id": "data1.txt",
+      "@type": "File",
+      "description": "One of hopefully many Data Entities",
+      "author": {"@id": "#alice"},
+      "contentLocation":  {"@id": "http://sws.geonames.org/8152662/"}
+    },
+    {
+      "@id": "data2.txt",
+      "@type": "File"
+    },
+
+    {
+      "@id": "#alice",
+      "@type": "Person",
+      "name": "Alice",
+      "description": "One of hopefully many Contextual Entities"
+    },
+    {
+      "@id": "http://sws.geonames.org/8152662/",
+      "@type": "Place",
+      "name": "Catalina Park"
+    }
+ ]
+}
+`)
+
+// galaxyCrate is an example of a ro-crate-metadata.json file found
+// in the wild.
+var galaxyCrate []byte = []byte(`
+{
+    "@context": "https://w3id.org/ro/crate/1.1/context",
+    "@graph": [
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate/1.1"
+            },
+            "about": {
+                "@id": "./"
+            }
+        },
+        {
+            "@id": "./",
+            "@type": [
+                "Dataset",
+                "LearningResource"
+            ],
+            "name": "Demo Crate",
+            "description": "a demo crate for Galaxy training",
+            "datePublished": "2024-03-08",
+            "publisher": "https://ror.org/0abcdef00",
+            "license": {
+                "@id": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
+                "@type": "CreativeWork",
+                "name": "CC BY-NC-SA 4.0 International",
+                "description": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International"
+            },
+            "author": {
+                "@id": "https://orcid.org/0000-0000-0000-0000"
+            },
+            "hasPart": [
+                {
+                    "@id": "data.csv"
+                }
+            ],
+			"contentUrl": "http://example.com/resource/data"
+        },
+        {
+            "@id": "data.csv",
+            "@type": "File",
+            "name": "Rainfall Katoomba 2022-02",
+            "description": "Rainfall data for Katoomba in NSW Australia, captured February 2022.",
+            "encodingFormat": "text/csv",
+            "license": {
+                "@id": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+                "@type": "CreativeWork",
+                "name": "CC BY-NC-SA 4.0 International",
+                "description": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International"
+            }
+        },
+        {
+            "@id": "https://orcid.org/0000-0000-0000-0000",
+            "@type": "Person",
+            "givenName": "Jane",
+            "familyName": "Smith",
+            "affiliation": {
+                "@id": "https://ror.org/0abcdef00"
+            }
+        },
+        {
+            "@id": "https://ror.org/0abcdef00",
+            "@type": "Organization",
+            "name": "Example University",
+            "url": "https://www.example.org"
+        }
+    ]
+}
+`)
+
+// emptyCrate provides a way to test the lacn of information, e.g.
+// when providign summary information.
+var emptyCrate []byte = []byte(`
+{
+    "@context": "https://w3id.org/ro/crate/1.1/context",
+    "@graph": [
+        {
+            "@type": "CreativeWork",
+            "@id": "ro-crate-metadata.json",
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate/1.1"
+            },
+            "about": {
+                "@id": "./"
+            }
+        },
+        {
+        },
+        {
+        }
+    ]
+}
+`)

--- a/pkg/rocrate/rocrate_test.go
+++ b/pkg/rocrate/rocrate_test.go
@@ -1,0 +1,634 @@
+package rocrate
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+// TestContexts ensures that we can open an empty JSON-LD as expected
+// and reason about it.
+func TestContexts(t *testing.T) {
+
+	expectedContext := "https://w3id.org/ro/crate/1.1/context"
+
+	simpleContextRes := bytes.NewBuffer(simpleContext)
+	res, err := ProcessMetadataStream(simpleContextRes)
+
+	if err != nil {
+		t.Errorf("error processing simpleContext: %s", err)
+	}
+	if res.Context() != expectedContext {
+		t.Errorf("context wasn't read successfully, got: '%s'", res.Context())
+	}
+	if len(res.Graph) != 0 {
+		t.Errorf("expecting empty graph, got graph len: '%d'", len(res.Graph))
+	}
+
+	complexContextRes := bytes.NewBuffer(complexContext)
+	res, err = ProcessMetadataStream(complexContextRes)
+
+	if err != nil {
+		t.Errorf("error processing complexContext: %s", err)
+	}
+	if res.Context() != expectedContext {
+		t.Errorf("context wasn't read successfully, got: '%s'", res.Context())
+	}
+	if len(res.Graph) != 0 {
+		t.Errorf("expecting empty graph, got graph len: '%d'", len(res.Graph))
+	}
+}
+
+type stringTest struct {
+	label    string
+	testData []byte
+	compare1 []string
+	compare2 []string
+}
+
+var stringTests []stringTest = []stringTest{
+	stringTest{
+		"name",
+		nameTest,
+		[]string{"name one", "name two"},
+		[]string{"name one"},
+	},
+	stringTest{
+		"keyword",
+		keywordTest,
+		[]string{"kw1", "kw2"},
+		[]string{"kw1"},
+	},
+	stringTest{
+		"type",
+		typeTest,
+		[]string{"Person", "Artist"},
+		[]string{"Person"},
+	},
+}
+
+// getStringSliceValue gives us some way of dynamically accessing
+// attributes to avoid a decent amount of code replication.
+func getStringSliceValue(data graph, label string) []string {
+	switch label {
+	case "name":
+		return data.Name.Value()
+	case "keyword":
+		return data.Keywords.Value()
+	case "type":
+		return data.Type.Value()
+	}
+	return []string{""}
+}
+
+// TestStringVariants tests our ability to decode single-value strings
+// or slices. We convert the single-value to a slice so we expect a
+// slice array at all times.
+func TestStringVariants(t *testing.T) {
+	for _, test := range stringTests {
+		variantTest := bytes.NewBuffer(test.testData)
+		res, err := ProcessMetadataStream(variantTest)
+
+		if err != nil {
+			t.Errorf("%s: cannot process input ('%s')", test.label, err)
+		}
+		if len(res.Graph) != 2 {
+			fmt.Printf("test data is incorrect length: '%d'", len(res.Graph))
+		}
+		testID := res.Graph[0].ID
+		if testID != "test1" {
+			t.Errorf("test ID is incorrect: %s", testID)
+		}
+		value := getStringSliceValue(res.Graph[0], test.label)
+		if !slices.Equal(value, test.compare1) {
+			t.Errorf(
+				"%s: string variant: '%v' result doesn't match expected: '%v'",
+				fmt.Sprintf("%s test 1", test.label),
+				value,
+				test.compare1,
+			)
+		}
+		testID = res.Graph[1].ID
+		if testID != "test2" {
+			t.Errorf("test ID is incorrect: %s", testID)
+		}
+		value = getStringSliceValue(res.Graph[1], test.label)
+		if !slices.Equal(value, test.compare2) {
+			t.Errorf(
+				"%s: string variant: '%v' result doesn't match expected: '%v'",
+				fmt.Sprintf("%s test 2", test.label),
+				value,
+				test.compare2,
+			)
+		}
+	}
+}
+
+type nodeTest struct {
+	label    string
+	testData []byte
+	compare1 []nodeIdentifier
+	compare2 []nodeIdentifier
+}
+
+var nodeTests []nodeTest = []nodeTest{
+	nodeTest{
+		"author",
+		authorTest,
+		[]nodeIdentifier{
+			nodeIdentifier{"https://orcid.org/1234-0003-1974-0000"},
+			nodeIdentifier{"#Yann"},
+			nodeIdentifier{"#Organization-SMUC"},
+		},
+		[]nodeIdentifier{
+			nodeIdentifier{"https://orcid.org/0000-0003-1974-1234"},
+		},
+	},
+	nodeTest{
+		"hasPart",
+		hasPartTest,
+		[]nodeIdentifier{
+			nodeIdentifier{"part1"},
+		},
+		[]nodeIdentifier{
+			nodeIdentifier{"part1"},
+			nodeIdentifier{"part2"},
+			nodeIdentifier{"part3"},
+		},
+	},
+	nodeTest{
+		"license",
+		licenseTest,
+		[]nodeIdentifier{
+			nodeIdentifier{"https://spdx.org/licenses/license1"},
+		},
+		[]nodeIdentifier{
+			nodeIdentifier{"http://spdx.org/licenses/license2"},
+		},
+	},
+}
+
+// getNodeIdentifierSliceValue allows us to get values more dynamically
+// from the nodeIdentifier tests.
+func getNodeIdentifierSliceValue(data graph, label string) []nodeIdentifier {
+	switch label {
+	case "author":
+		return data.Author.Value()
+	case "license":
+		return data.License.Value()
+	case "hasPart":
+		return data.HasPart.Value()
+	}
+	return []nodeIdentifier{}
+}
+
+// TestNodeIdentifierVariants tests the conversion of single-values to
+// a slice of nodeIdentifiers.
+func TestNodeIdentifierVariants(t *testing.T) {
+	for _, test := range nodeTests {
+		variantTest := bytes.NewBuffer(test.testData)
+		res, err := ProcessMetadataStream(variantTest)
+
+		if err != nil {
+			t.Errorf("%s: cannot process input ('%s')", test.label, err)
+		}
+		if len(res.Graph) != 2 {
+			fmt.Printf(
+				"%s: test data is incorrect length: '%d'",
+				test.label,
+				len(res.Graph),
+			)
+		}
+		testID := res.Graph[0].ID
+		if testID != "test1" {
+			t.Errorf("test ID is incorrect: %s", testID)
+		}
+		value := getNodeIdentifierSliceValue(res.Graph[0], test.label)
+		for idx, v := range value {
+			if v.ID != test.compare1[idx].ID {
+				t.Errorf(
+					"%s: string variant: '%v' result doesn't match expected: '%v'",
+					fmt.Sprintf("%s test 1", test.label),
+					v,
+					test.compare1[idx],
+				)
+			}
+		}
+		testID = res.Graph[1].ID
+		if testID != "test2" {
+			t.Errorf("test ID is incorrect: %s", testID)
+		}
+		value = getNodeIdentifierSliceValue(res.Graph[1], test.label)
+		for idx, v := range value {
+			if v.ID != test.compare2[idx].ID {
+				t.Errorf(
+					"%s: string variant: '%v' result doesn't match expected: '%v'",
+					fmt.Sprintf("%s test 2", test.label),
+					v,
+					test.compare2[idx],
+				)
+			}
+		}
+	}
+}
+
+// TestNewSummary ensures new summary is as safe as possible.
+func TestNewSummary(t *testing.T) {
+	summary := newSummary()
+	structType := reflect.TypeOf(summary)
+	structVal := reflect.ValueOf(summary)
+	fieldNum := structVal.NumField()
+	for i := 0; i < fieldNum; i++ {
+		field := structVal.Field(i)
+		if fmt.Sprintf("%s", field.Type()) == "string" {
+			continue
+		}
+		fieldName := structType.Field(i).Name
+		isSet := field.IsValid() && !field.IsZero()
+		if !isSet {
+			t.Errorf("summary constructor isn't setting: %s", fieldName)
+		}
+	}
+}
+
+// TestNewGocflSummary ensures new gocfl summary is as safe as possible.
+func TestNewGocflSummary(t *testing.T) {
+	summary := newGocflSummary()
+	structType := reflect.TypeOf(summary)
+	structVal := reflect.ValueOf(summary)
+	fieldNum := structVal.NumField()
+	for i := 0; i < fieldNum; i++ {
+		field := structVal.Field(i)
+		if fmt.Sprintf("%s", field.Type()) == "string" {
+			continue
+		}
+		fieldName := structType.Field(i).Name
+		isSet := field.IsValid() && !field.IsZero()
+		if !isSet {
+			t.Errorf("summary constructor isn't setting: %s", fieldName)
+		}
+	}
+}
+
+type metadataTest struct {
+	label        string
+	testData     []byte
+	summary      RocrateSummary
+	gocflSummary GocflSummary
+}
+
+var metadataTests []metadataTest = []metadataTest{
+	metadataTest{
+		"empty",
+		emptyCrate,
+		RocrateSummary{
+			// ID
+			"",
+			// Name
+			[]string{},
+			// Type
+			[]string{},
+			// Description
+			[]string{},
+			// DatePublished
+			"",
+			// Author
+			[]string{},
+			// License
+			"",
+			// HasPart
+			[]string{},
+			// ContentURL
+			[]string{},
+			// Keywords
+			[]string{},
+			// Publisher
+			[]string{},
+			// About
+			"./",
+		},
+		GocflSummary{
+			// signature
+			"",
+			// title
+			"",
+			// description
+			"",
+			// created
+			"",
+			// sets
+			"",
+			// keywords
+			"",
+			// licenses
+			"",
+			// provided by caller.
+			"",
+			"",
+			"",
+			"",
+			"",
+		},
+	},
+	metadataTest{
+		"afternoon drinks",
+		afternoonDrinks,
+		RocrateSummary{
+			// ID
+			"./RC0E772B3021E7E40C2BBDE657",
+			// Name
+			[]string{"A study of my afternoon drinks"},
+			// Type
+			[]string{"Dataset"},
+			// Description
+			[]string{
+				"A study of my afternoon consumption one week in 2018",
+				"Exported from Dataverse",
+			},
+			// DatePublished
+			"2018",
+			// Author
+			[]string{"#Ross_Spencer-1"},
+			// License
+			"https://spdx.org/licenses/CC0-1.0.html",
+			// HasPart
+			[]string{
+				"metadata/agents.json",
+				"metadata/dataset.json",
+				"Drinkscitation-endnote.xml",
+				"Drinks.tab",
+				"Drinks.csv",
+				"Drinkscitation-ris.ris",
+				"Drinkscitation-bib.bib",
+				"Drinks.RData",
+				"Drinks-ddi.xml",
+			},
+			// ContentURL
+			nil,
+			// Keywords
+			[]string{
+				"dataverse",
+				"study",
+				"observational-study",
+			},
+			// Publisher
+			[]string{
+				"https://ror.org/02s6k3f65",
+			},
+			// About
+			"./RC0E772B3021E7E40C2BBDE657",
+		},
+		GocflSummary{
+			// signature
+			"./RC0E772B3021E7E40C2BBDE657",
+			// title
+			"A study of my afternoon drinks",
+			// description
+			"A study of my afternoon consumption one week in 2018; Exported from Dataverse",
+			// created
+			"2018",
+			// sets
+			"Dataset",
+			// keywords
+			"dataverse; study; observational-study",
+			// licenses
+			"https://spdx.org/licenses/CC0-1.0.html",
+			// provided by caller.
+			"",
+			"",
+			"",
+			"",
+			"",
+		},
+	},
+	metadataTest{
+		"carpentries",
+		carpentriesCrate,
+		RocrateSummary{
+			// ID
+			"./",
+			// Name
+			[]string{
+				"Example dataset for RO-Crate specification",
+			},
+			// Type
+			[]string{
+				"Dataset",
+				"LearningResource",
+			},
+			// Description
+			[]string{
+				"Official rainfall readings for Katoomba, NSW 2022, Australia",
+			},
+			// DatePublished
+			"2023-05-22T12:03:00+0100",
+			// Author
+			[]string{
+				"https://orcid.org/0000-0002-1825-0097",
+			},
+			// License
+			"http://spdx.org/licenses/CC0-1.0",
+			// HasPart
+			[]string{
+				"data.csv",
+			},
+			// ContentURL
+			[]string{},
+			// Keywords
+			[]string{},
+			// Publisher
+			[]string{
+				"https://ror.org/05gq02987",
+			},
+			// About
+			"./",
+		},
+		GocflSummary{
+			// signature
+			"./",
+			// title
+			"Example dataset for RO-Crate specification",
+			// description
+			"Official rainfall readings for Katoomba, NSW 2022, Australia",
+			// created
+			"2023-05-22T12:03:00+0100",
+			// sets
+			"Dataset; LearningResource",
+			// keywords
+			"",
+			// licenses
+			"http://spdx.org/licenses/CC0-1.0",
+			// provided by caller.
+			"",
+			"",
+			"",
+			"",
+			"",
+		},
+	},
+	metadataTest{
+		"spec",
+		specCrate,
+		RocrateSummary{
+			// ID
+			"./",
+			// Name
+			[]string{
+				"Example RO-Crate",
+			},
+			// Type
+			[]string{
+				"Dataset",
+			},
+			// Description
+			[]string{
+				"The RO-Crate Root Data Entity",
+			},
+			// DatePublished
+			"",
+			// Author
+			[]string{},
+			// License
+			"",
+			// HasPart
+			[]string{
+				"data1.txt",
+				"data2.txt",
+			},
+			// ContentURL
+			[]string{},
+			// Keywords
+			[]string{},
+			// Publisher
+			[]string{},
+			// About
+			"./",
+		},
+		GocflSummary{
+			// signature
+			"./",
+			// title
+			"Example RO-Crate",
+			// description
+			"The RO-Crate Root Data Entity",
+			// created
+			"",
+			// sets
+			"Dataset",
+			// keywords
+			"",
+			// licenses
+			"",
+			// provided by caller.
+			"",
+			"",
+			"",
+			"",
+			"",
+		},
+	},
+	metadataTest{
+		"galaxy",
+		galaxyCrate,
+		RocrateSummary{
+			// ID
+			"./",
+			// Name
+			[]string{
+				"Demo Crate",
+			},
+			// Type
+			[]string{
+				"Dataset",
+				"LearningResource",
+			},
+			// Description
+			[]string{
+				"a demo crate for Galaxy training",
+			},
+			// DatePublished
+			"2024-03-08",
+			// Author
+			[]string{
+				"https://orcid.org/0000-0000-0000-0000",
+			},
+			// License
+			"https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
+			// HasPart
+			[]string{
+				"data.csv",
+			},
+			// ContentURL
+			[]string{
+				"http://example.com/resource/data",
+			},
+			// Keywords
+			[]string{},
+			// Publisher
+			[]string{
+				"https://ror.org/0abcdef00",
+			},
+			// About
+			"./",
+		},
+		GocflSummary{
+			// signature
+			"./",
+			// title
+			"Demo Crate",
+			// description
+			"a demo crate for Galaxy training",
+			// created
+			"2024-03-08",
+			// sets
+			"Dataset; LearningResource",
+			// keywords
+			"",
+			// licenses
+			"https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
+			// provided by caller.
+			"",
+			"",
+			"",
+			"",
+			"",
+		},
+	},
+}
+
+// TestMetadata provides more generic testing of the test data within
+// this package.
+func TestMetadata(t *testing.T) {
+	for _, test := range metadataTests {
+		variantTest := bytes.NewBuffer(test.testData)
+		processed, err := ProcessMetadataStream(variantTest)
+		if err != nil {
+			t.Errorf("%s: cannot process input ('%s')", test.label, err)
+		}
+		res, _ := processed.Summary()
+		if diff := deep.Equal(res, test.summary); diff != nil {
+			t.Errorf("%s summary metadata doesn't match: %s", test.label, diff)
+		}
+	}
+}
+
+// TestGOCFLMetadata provides more generic testing the summary output
+// of the GOCFL struct.
+func TestGOCFLMetadata(t *testing.T) {
+	for _, test := range metadataTests {
+		variantTest := bytes.NewBuffer(test.testData)
+		processed, _ := ProcessMetadataStream(variantTest)
+		currentTime = func(bool) string {
+			// Mock getTime function.
+			return ""
+		}
+		res, _ := processed.GOCFLSummary()
+		if diff := deep.Equal(res, test.gocflSummary); diff != nil {
+			t.Errorf("%s gocfl metadata doesn't match: %s", test.label, diff)
+		}
+	}
+}


### PR DESCRIPTION
* first-draft ro-crate package and extension.
* docs shortcut added to justfile.
* minor cleanup along the way.
* updated configuration options for ro-crate.

----

TODO:

* [ ] godoc to justfile: `godoc -http=localhost:6060`
* [x] info.json mapping.
* [x] refactor and variable naming.
* [x] ro-crate tests.
* [x] disable metafile when using ro-crate.
* [ ] check previous idioms.
* [ ] display functions required for gocfl. 
* [ ] complete docs.
* [ ] additional tests, cleanup as required.
* [ ] Merge with current GOCFL branch (currently behind by 20+ commits due to fs errors).
* [ ] Include additional examples from the RO-CRATE site, e.g. a good one: https://www.researchobject.org/ro-crate/specification/1.1/workflows#complete-workflow-example.
* [ ] merge with current branches.
* [ ] document info.json as mandatory and that it populates mets.xml and premis.xml

Notes:

* RO-CRATE Context: https://www.researchobject.org/ro-crate/specification/1.1/context.jsonld
* MAPPING: https://docs.google.com/document/d/1JjkFUGmD-xW6GzYGEGwg_qIOhkbsxbPKoaFfYNIm24M/edit?tab=t.0
* OLD: https://docs.google.com/document/d/11z61gLmJhe5OXgpJHT38uG6uyWMXUEicAlZQ8lS1cek/edit?tab=t.0#heading=h.o9g3dbdg346t
* OLD: https://gist.github.com/ross-spencer/21389965367899749cc4b4b5545c5857
* Additional notes to be added below from prev. meeting.

METS/PREMIS:

```xml
ross-spencer@exponential-decay:/tmp/gocfl-test/rs_dir_15/v1/content/metadata$ cat mets.xml | grep xx
      <name>rs via info.json</name>
      <note>1 rs road via info.json</note>
ross-spencer@exponential-decay:/tmp/gocfl-test/rs_dir_15/v1/content/metadata$ cat premis.xml | grep xx
    <agentName>rs via info.json</agentName>
      <agentIdentifierValue>1 rs road via info.json</agentIdentifierValue>
    <agentName>rs via info.json</agentName>
```